### PR TITLE
Remove unnecessary Rc<RefCell> in AI

### DIFF
--- a/src/game/game_state.rs
+++ b/src/game/game_state.rs
@@ -328,8 +328,6 @@ pub type PlayResult = std::result::Result<(RoundResult, usize), PlayError>;
 mod test {
     use crate::game::killer_ai::*;
     use crate::game::victim_ai::*;
-    use std::cell::RefCell;
-    use std::rc::Rc;
 
     /// Runs a simulation of the game with AI players.
     #[test]
@@ -344,28 +342,27 @@ mod test {
         // Play matches
         for _ in 0..GAME_COUNT {
             // Create a game state
-            let state = Rc::new(RefCell::new(super::GameState::new()));
-            state.borrow_mut().gen_state();
+            let mut state = super::GameState::new();
+            state.gen_state();
 
             // Create AI plays
-            let mut killer = KillerAI::new(state.clone());
-            let mut victim = VictimAI::new(state.clone());
+            let mut killer = KillerAI::new();
+            let mut victim = VictimAI::new();
 
             // Play game until there is a winner
             loop {
                 // Have each AI make a move
-                let killer_move = killer.play();
-                let victim_move = victim.play();
+                let killer_move = killer.play(&mut state);
+                let victim_move = victim.play(&mut state);
 
                 // Submit moves to the game state
                 let res = state
-                    .borrow_mut()
                     .play(victim_move, killer_move)
                     .expect("Something went wrong during play");
 
                 // Place trap if evaded
                 if res.0 == super::RoundResult::Evaded {
-                    victim.place_trap();
+                    victim.place_trap(&mut state);
                 }
                 // Break if someone won
                 else if res.0 == super::RoundResult::Caught {

--- a/src/game/killer_ai.rs
+++ b/src/game/killer_ai.rs
@@ -1,38 +1,34 @@
 use rand::Rng;
-use std::cell::RefCell;
-use std::rc::Rc;
 
 use crate::game::game_state::*;
 use crate::game::section::*;
 
 /// An AI version of the killer to be used in testing/single player
 pub struct KillerAI {
-    /// The game state the killer plays in
-    state: Rc<RefCell<GameState>>,
-
     /// List of sections to check
     sections: Vec<usize>,
+}
+
+impl Default for KillerAI {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl<'a> KillerAI {
     /// Constructor.
     ///
     /// Only argument is the game state.
-    pub fn new(state: Rc<RefCell<GameState>>) -> KillerAI {
+    pub fn new() -> KillerAI {
         KillerAI {
-            state,
             sections: (0..SECTION_COUNT).collect(),
         }
     }
 
     /// Play a round of the game as the killer.
-    pub fn play(&mut self) -> (usize, usize) {
+    pub fn play(&mut self, state: &GameState) -> (usize, usize) {
         // Get last game result values
-        let last_result: (RoundResult, usize);
-        {
-            let state = self.state.borrow();
-            last_result = state.last_result;
-        }
+        let last_result = &state.last_result;
 
         // If a car part was found in the last round, remove that section
         // from our list of sections to check


### PR DESCRIPTION
This patch will get rid of all the `Rc<RefCell>` use in the AI. Makes things a little cleaner.